### PR TITLE
Dragon Caves

### DIFF
--- a/drizztsaga/worldmap/bgee/bpwm_links_all.tbl
+++ b/drizztsaga/worldmap/bgee/bpwm_links_all.tbl
@@ -6,13 +6,11 @@ AR1000   E        F_7777     #WMtravel    6        1         N    N    N    N   
 AR1000   E        F_0111     #WMtravel    4        1         N    N    N    N    N    0
 AR1000   E        F_0222     #WMtravel    4        1         N    N    N    N    N    0
 AR1000   E        F_9898     #WMtravel    6        1         N    N    N    N    N    0
-AR1000   E        F_7779     #Icewind03   6        1         N    N    N    N    N    0
 
 AR4200   N        F_7777     #WMtravel    13       1         N    N    N    N    N    0
 AR4200   N        F_0111     #WMtravel    11       1         N    N    N    N    N    0
 AR4200   N        F_0222     #WMtravel    11       1         N    N    N    N    N    0
 AR4200   N        F_9898     #WMtravel    13       1         N    N    N    N    N    0
-AR4200   N        F_7779     #Icewind03   13       1         N    N    N    N    N    0
 
 F_0111   S        AR1000     Exit1400     4        1         N    N    N    N    N    0
 F_0111   S        AR4200     N            11       1         N    N    N    N    N    0

--- a/drizztsaga/worldmap/bgt/bpwm_links_all.tbl
+++ b/drizztsaga/worldmap/bgt/bpwm_links_all.tbl
@@ -6,13 +6,11 @@ ARU000   E        F_7777     #WMtravel    6        1         N    N    N    N   
 ARU000   E        F_0111     #WMtravel    8        1         N    N    N    N    N    0
 ARU000   E        F_0222     #WMtravel    10       1         N    N    N    N    N    0
 ARU000   E        F_9898     #WMtravel    11	   1         N    N    N    N    N    0
-ARU000   E        F_7779     #Icewind03   6        1         N    N    N    N    N    0
 
 AR3100   N        F_7777     #WMtravel    15       1         N    N    N    N    N    0
 AR3100   N        F_0111     #WMtravel    17       1         N    N    N    N    N    0
 AR3100   N        F_0222     #WMtravel    19       1         N    N    N    N    N    0
 AR3100   N        F_9898     #WMtravel    20       1	     N    N    N    N    N    0
-AR3100   N        F_7779     #Icewind03   15       1         N    N    N    N    N    0
 
 F_0111   S        ARU000     EXIT8300     8        1		 N    N    N    N    N    0
 F_0111   S        AR3100     EXIT9600     17       1		 N    N    N    N    N    0

--- a/drizztsaga/worldmap/tutu/bpwm_links_all.tbl
+++ b/drizztsaga/worldmap/tutu/bpwm_links_all.tbl
@@ -6,13 +6,11 @@ FW1000   E        F_7777     #WMtravel    6        1         N    N    N    N   
 FW1000   E        F_0111     #WMtravel    4        1         N    N    N    N    N    0
 FW1000   E        F_0222     #WMtravel    4        1         N    N    N    N    N    0
 FW1000   E        F_9898     #WMtravel    6        1         N    N    N    N    N    0
-FW1000   E        F_7779     #Icewind03   6        1         N    N    N    N    N    0
 
 FW4200   N        F_7777     #WMtravel    13       1         N    N    N    N    N    0
 FW4200   N        F_0111     #WMtravel    11       1         N    N    N    N    N    0
 FW4200   N        F_0222     #WMtravel    11       1         N    N    N    N    N    0
 FW4200   N        F_9898     #WMtravel    13       1         N    N    N    N    N    0
-FW4200   N        F_7779     #Icewind03   13       1         N    N    N    N    N    0
 
 F_0111   S        FW1000     Exit1400     4        1         N    N    N    N    N    0
 F_0111   S        FW4200     N            11       1         N    N    N    N    N    0


### PR DESCRIPTION
Currently, the area is accessible via world map before even meeting Drizzt or initiated the quest. this is linked to travel links that go from Ulgoth's Beard and Fisherman Lake.